### PR TITLE
Adopt Ubiquitous_iterator

### DIFF
--- a/external/bolt/include/bolt/amp/iterator/addressof.h
+++ b/external/bolt/include/bolt/amp/iterator/addressof.h
@@ -44,7 +44,7 @@ namespace amp{
 	template <typename Iterator>
     static
     inline
-    typename bolt::amp::device_vector<typename Iterator::value_type>::iterator
+    Iterator
     create_mapped_iterator(bolt::amp::device_vector_tag, Iterator itr, int sz, bool var, ::bolt::amp::control &ctl)
     {
         return itr;

--- a/external/bolt/include/bolt/amp/iterator/ubiquitous_iterator.h
+++ b/external/bolt/include/bolt/amp/iterator/ubiquitous_iterator.h
@@ -1,0 +1,92 @@
+/***************************************************************************
+*     2012,2014 Advanced Micro Devices, Inc. All rights reserved.
+*
+*   Licensed under the Apache License, Version 2.0 (the "License");
+*   you may not use this file except in compliance with the License.
+*   You may obtain a copy of the License at
+*
+*       http://www.apache.org/licenses/LICENSE-2.0
+*
+*   Unless required by applicable law or agreed to in writing, software
+*   distributed under the License is distributed on an "AS IS" BASIS,
+*   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*   See the License for the specific language governing permissions and
+*   limitations under the License.
+
+***************************************************************************/
+#pragma once
+
+#include "../device_vector.h"
+
+#include <cstddef>
+#include <iterator>
+
+namespace bolt
+{
+    namespace amp
+    {
+        template<typename T>
+        class Ubiquitous_iterator : public std::iterator<device_vector_tag, T> {
+//            friend
+//            inline
+//            Ubiquitous_iterator create_mapped_iterator(
+//                device_vector_tag,
+//                Ubiquitous_iterator x,
+//                int,
+//                bool,
+//                control&)
+//            {
+//                return x;
+//            }
+            friend
+            inline
+            Ubiquitous_iterator operator+(
+                Ubiquitous_iterator x, std::ptrdiff_t dx) [[cpu]][[hc]]
+            {
+                return x += dx;
+            }
+
+            friend
+            inline
+            std::ptrdiff_t operator-(
+                const Ubiquitous_iterator& x,
+                const Ubiquitous_iterator& y) [[cpu]][[hc]]
+            {
+                return x.p_ - y.p_;
+            }
+
+            T* p_;
+        public:
+            Ubiquitous_iterator() [[cpu]][[hc]] = default;
+            explicit
+            Ubiquitous_iterator(T* p) [[cpu]][[hc]] : p_{p} {}
+
+            T& operator[](std::ptrdiff_t dx) const [[cpu]][[hc]]
+            {
+                return p_[dx];
+            }
+            T& operator[](std::ptrdiff_t dx) [[cpu]][[hc]] { return p_[dx]; }
+
+            Ubiquitous_iterator& operator+=(std::ptrdiff_t dx) [[cpu]][[hc]]
+            {
+                p_ += dx;
+                return *this;
+            }
+
+            // Bolt glue.
+            std::ptrdiff_t m_Index = 0;
+            const Ubiquitous_iterator& getContainer() const { return *this; }
+            Ubiquitous_iterator& getContainer() { return *this; }
+
+            T* data() const { return p_; }
+            T* data() { return p_; }
+            // Bolt glue.
+        };
+        template<typename T>
+        inline
+        Ubiquitous_iterator<T> make_ubiquitous_iterator(T* p) [[cpu]][[hc]]
+        {
+            return Ubiquitous_iterator<T>{p};
+        }
+    }
+}

--- a/lib/THCUNN/RReLU.cu
+++ b/lib/THCUNN/RReLU.cu
@@ -5,7 +5,7 @@
 #include <curand.h>
 #include <curand_kernel.h>
 #else
-#include "hip/hcc.h"
+#include <hip/hip_hcc.h>
 #include "MTGP/hiprand_mtgp32.h"
 #endif
 
@@ -122,15 +122,15 @@ void THNN_CudaRReLU_updateOutput(THCState *state, THCudaTensor *input, THCudaTen
     if (inplace)
     {
 #ifdef CURAND_PATH
-      hipLaunchKernelGGL((rreluUpdateOutputTrain), dim3(NUM_BLOCKS(n)), dim3(BLOCK_SIZE), 0, THCState_getCurrentStream(state), 
+      hipLaunchKernelGGL((rreluUpdateOutputTrain), dim3(NUM_BLOCKS(n)), dim3(BLOCK_SIZE), 0, THCState_getCurrentStream(state),
         n, gen_states, input_data, noise_data, input_data, lower, upper);
       THCudaTensor_set(state, output, input);
 #else
-      hipStream_t currentStream = THCState_getCurrentStream(state); 
-      hc::accelerator_view* current_accl_view; 
-      hipHccGetAcceleratorView(currentStream, &current_accl_view); 
-      user_uniform_kernel(*current_accl_view, gen_states, noise_data, user_uniform_functor(lower, upper)); 
-      hipLaunchKernelGGL((rreluUpdateOutputTrain), dim3(NUM_BLOCKS(n)), dim3(BLOCK_SIZE), 0, THCState_getCurrentStream(state), 
+      hipStream_t currentStream = THCState_getCurrentStream(state);
+      hc::accelerator_view* current_accl_view;
+      hipHccGetAcceleratorView(currentStream, &current_accl_view);
+      user_uniform_kernel(*current_accl_view, gen_states, noise_data, user_uniform_functor(lower, upper));
+      hipLaunchKernelGGL((rreluUpdateOutputTrain), dim3(NUM_BLOCKS(n)), dim3(BLOCK_SIZE), 0, THCState_getCurrentStream(state),
         n, gen_states, input_data, noise_data, input_data, lower, upper);
       THCudaTensor_set(state, output, input);
 #endif
@@ -140,14 +140,14 @@ void THNN_CudaRReLU_updateOutput(THCState *state, THCudaTensor *input, THCudaTen
       THCudaTensor_resizeAs(state, output, input);
       float *output_data = THCudaTensor_data(state, output);
 #ifdef CURAND_PATH
-      hipLaunchKernelGGL((rreluUpdateOutputTrain), dim3(NUM_BLOCKS(n)), dim3(BLOCK_SIZE), 0, THCState_getCurrentStream(state), 
+      hipLaunchKernelGGL((rreluUpdateOutputTrain), dim3(NUM_BLOCKS(n)), dim3(BLOCK_SIZE), 0, THCState_getCurrentStream(state),
         n, gen_states, input_data, noise_data, output_data, lower, upper);
 #else
-      hipStream_t currentStream = THCState_getCurrentStream(state); 
-      hc::accelerator_view* current_accl_view; 
-      hipHccGetAcceleratorView(currentStream, &current_accl_view); 
-      user_uniform_kernel(*current_accl_view, gen_states, noise_data, user_uniform_functor(lower, upper)); 
-      hipLaunchKernelGGL((rreluUpdateOutputTrain), dim3(NUM_BLOCKS(n)), dim3(BLOCK_SIZE), 0, THCState_getCurrentStream(state), 
+      hipStream_t currentStream = THCState_getCurrentStream(state);
+      hc::accelerator_view* current_accl_view;
+      hipHccGetAcceleratorView(currentStream, &current_accl_view);
+      user_uniform_kernel(*current_accl_view, gen_states, noise_data, user_uniform_functor(lower, upper));
+      hipLaunchKernelGGL((rreluUpdateOutputTrain), dim3(NUM_BLOCKS(n)), dim3(BLOCK_SIZE), 0, THCState_getCurrentStream(state),
         n, gen_states, input_data, noise_data, output_data, lower, upper);
 #endif
     }


### PR DESCRIPTION
This adopts Ubiquitous_iterator in CUNN. It enables some previously disabled functionality and corrects create_mapped_iterator in Bolt to seamlessly work with Ubiquitous_iterator.